### PR TITLE
Adding support for log rotation for distributed loggers.

### DIFF
--- a/BroControl/cron.py
+++ b/BroControl/cron.py
@@ -121,10 +121,18 @@ class CronTasks:
         if self.config.logexpireminutes == 0 and self.config.statslogexpireinterval == 0:
             return
 
-        success, output = execute.run_localcmd(os.path.join(self.config.scriptsdir, "expire-logs"))
+        expirelogs=os.path.join(self.config.scriptsdir, "expire-logs")
+        cmds=[]
+        for node in self.config.nodestore:
+            if node.split('-')[0] == 'logger':
+                cmds.append((self.config.nodestore[node], expirelogs, []))
 
-        if not success:
-            self.ui.error("expire-logs failed\n%s" % output)
+        for (node, success, output) in self.executor.run_cmds(cmds, shell=True, helper=False):
+            if not success:
+                self.ui.error("expire-logs failed for node %s\n" % node)
+                if output:
+                    self.ui.error(output)
+
 
     def expire_crash(self):
         if self.config.crashexpireinterval == 0:


### PR DESCRIPTION
Reference the issue I filed here: https://github.com/zeek/zeek/issues/225

Per my conversation with @jsiwek, Broctl does not currently support log rotation for logger nodes which are not local: `success, output = execute.run_localcmd(os.path.join(self.config.scriptsdir, "expire-logs"))`

In my case I have two management nodes which both have loggers. Logger-1 rotates as expected, logger-2 never rotates logs.

The gist of this change is that I enumerate all the "logger" nodes from the "nodestore" object. I then swapped out `execute.run_localcmd` with `self.executor.run_cmds` which runs commands remotely. Finally I used what looks like broctl's standard error logging capability.

Tested on my 2 node dev cluster (1 management/logger node, and 1 worker node). Along with my production cluster (2 management/logger nodes and 7 worker nodes). Everything behaves as I expected.

Please review this merge request and suggest changes; this is my first commit to broctl.

Best Regards,
-Stefan